### PR TITLE
Fix swid-repo-client documentation link

### DIFF
--- a/swid-repo-client/README.md
+++ b/swid-repo-client/README.md
@@ -10,4 +10,4 @@ mvn clean install
 
 This will produce a binary distributions archived using the ZIP and TAR/BZip2 formats.
 
-Instructions on using this tool can be found in the binary distributions or [here](src/main/README.txt).
+Instructions on using this tool can be found in the binary distributions or [here](src/main/distro/README.txt).


### PR DESCRIPTION
Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>

# Committer Notes

This fixes a link to documentation in swid-repo-client.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/oss-maven/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oss-maven/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?