### PR TITLE
[WIP] Revert swidval dependency

### DIFF
--- a/swid-repo-client/pom.xml
+++ b/swid-repo-client/pom.xml
@@ -106,7 +106,7 @@
 					<dependency>
 						<groupId>gov.nist.secauto.swid</groupId>
 						<artifactId>swid-maven-plugin</artifactId>
-						<version>0.6.2-SNAPSHOT</version>
+						<version>0.6.1</version>
 					</dependency>
 				</dependencies>
 				<executions>

--- a/swidval/pom.xml
+++ b/swidval/pom.xml
@@ -140,7 +140,7 @@
 					<dependency>
 						<groupId>gov.nist.secauto.swid</groupId>
 						<artifactId>swid-maven-plugin</artifactId>
-						<version>0.6.2-SNAPSHOT</version>
+						<version>0.6.1</version>
 					</dependency>
 				</dependencies>
 				<executions>


### PR DESCRIPTION
# Committer Notes

This patch series potentially fixes the build issue in [Issue 7](https://github.com/usnistgov/swid-tools/issues/7).  Another error arose when using the built swidval jar, which might or not be related.  This PR is being filed to trigger CI and see if CI also raises the same issue.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/oss-maven/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oss-maven/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable? *(No.)*
- [ ] Have you included examples of how to use your new feature(s)? *(No.)*
- [ ] Have you updated all website and readme documentation affected by the changes you made? *(No.)*
