### PR TITLE
Migrate distribution management from legacy host

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,11 +50,11 @@
 	<distributionManagement>
 		<snapshotRepository>
 			<id>ossrh</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+			<url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
 		</snapshotRepository>
 		<repository>
 			<id>ossrh</id>
-			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+			<url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
 		</repository>
 		<site>
 			<id>pages-site</id>
@@ -246,7 +246,7 @@
 			<repositories>
 				<repository>
 					<id>oss.sonatype.org-snapshot</id>
-					<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+					<url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
 					<releases>
 						<enabled>false</enabled>
 					</releases>
@@ -258,7 +258,7 @@
 			<pluginRepositories>
 				<pluginRepository>
 					<id>oss.sonatype.org-snapshot</id>
-					<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+					<url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
 					<releases>
 						<enabled>false</enabled>
 					</releases>


### PR DESCRIPTION
# Committer Notes

[Documentation from Sonatype](https://central.sonatype.org/publish/publish-maven/#distribution-management-and-authentication) describes the current deployment host as legacy.  This Pull Request implements updated guidance.


### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/oss-maven/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oss-maven/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?  *(Believed N/A - external service)*
- [x] Have you included examples of how to use your new feature(s)?  *(Believed N/A)*
- [x] Have you updated all website and readme documentation affected by the changes you made?  *(Believed N/A)*