### PR TITLE
Bump JDK to 17 due to Spring Framework >=6 dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,11 +36,11 @@ jobs:
       with:
         maven-version: 3.9.3
     - id: setup-java-deploy
-      name: Set up JDK 11 (deploy)
+      name: Set up JDK 17 (deploy)
       if: ${{ env.BUILD_SNAPSHOT == 'true' }}
       uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00
       with:
-        java-version: 11
+        java-version: 17
         distribution: 'temurin'
         cache: 'maven'
         server-id: ossrh # Value of the distributionManagement/repository/id field of the pom.xml
@@ -48,11 +48,11 @@ jobs:
         server-password: MAVEN_CENTRAL_TOKEN # env variable for token in deploy
         gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }} # Value of the GPG private key to import
         gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
-    - name: Set up JDK 11 (build only)
+    - name: Set up JDK 17 (build only)
       if:  ${{ steps.setup-java-deploy.outcome == 'skipped' }}
       uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00
       with:
-        java-version: 11
+        java-version: 17
         distribution: 'temurin'
         cache: 'maven'
     - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,10 @@ jobs:
       uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1
       with:
         maven-version: 3.9.3
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00
       with:
-        java-version: 11
+        java-version: 17
         distribution: 'temurin'
         cache: 'maven'
         server-id: ossrh # Value of the distributionManagement/repository/id field of the pom.xml


### PR DESCRIPTION
This is necessitated by a dependency update.

> As of Spring Framework 6.0, Spring requires Java 17+.

References:
* https://docs.spring.io/spring-framework/reference/overview.html